### PR TITLE
fix lenovo bug: no close mProgressBarView when play video

### DIFF
--- a/wkvideoplayer/src/main/java/com/android/tedcoder/wkvideoplayer/view/SuperVideoPlayer.java
+++ b/wkvideoplayer/src/main/java/com/android/tedcoder/wkvideoplayer/view/SuperVideoPlayer.java
@@ -188,7 +188,12 @@ public class SuperVideoPlayer extends RelativeLayout {
             mediaPlayer.setOnInfoListener(new MediaPlayer.OnInfoListener() {
                 @Override
                 public boolean onInfo(MediaPlayer mp, int what, int extra) {
-                    if (what == MediaPlayer.MEDIA_INFO_VIDEO_RENDERING_START) {
+                    /*
+                     * add what == MediaPlayer.MEDIA_INFO_VIDEO_TRACK_LAGGING
+                     * fix : return what == 700 in Lenovo low configuration Android System
+                     */
+                    if (what == MediaPlayer.MEDIA_INFO_VIDEO_RENDERING_START
+                            || what == MediaPlayer.MEDIA_INFO_VIDEO_TRACK_LAGGING) {
                         mProgressBarView.setVisibility(View.GONE);
                         setCloseButton(true);
                         initDLNAInfo();


### PR DESCRIPTION
你好，公司项目用到了你的AndroidVideoPlayer，节约了不少开发时间，现在想起来还是很高兴的，在这里表示感谢。

我们的测试人员发现一个问题:

测试机： Lenovo A750e Android4.1 

问题：点击视频后，加载好视频，开始播放了，ProgressBar还一直在转动，没有设置消失，但是视频能播放。

进一步跟踪发现：
      1.SuperVideoPlayer里的VideoView已经设置上了mOnPreparedListener。                          √
      2.系统级的回调MediaPlayer.OnPreparedListener也走到了onPrepared方法里。                 √
      3.最后的系统级回调MediaPlayer.OnInfoListener同样执行了onInfo方法。                           √
      4.唯独if (what == MediaPlayer.MEDIA_INFO_VIDEO_RENDERING_START)没走进去     ×

```
/** The player just pushed the very first video frame for rendering.
 * @see android.media.MediaPlayer.OnInfoListener
 */
public static final int MEDIA_INFO_VIDEO_RENDERING_START = 3;

/** The video is too complex for the decoder: it can't decode frames fast
 *  enough. Possibly only the audio plays fine at this stage.
 * @see android.media.MediaPlayer.OnInfoListener
 */
public static final int MEDIA_INFO_VIDEO_TRACK_LAGGING = 700;
```

what会为700，发现机器配置差会出现这里的问题。
